### PR TITLE
Fix unit tests for existing functionality (fixes invalid platform) & add new 'setAttributes' method for modifying existing user attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ var SNS = require('sns-mobile'),
 // EVENTS.DELETED_USER
 // EVENTS.ADD_USER_FAILED
 // EVENTS.ADDED_USER
+// EVENTS.ATTRIBUTES_UPDATE_FAILED
+// EVENTS.ATTRIBUTES_UPDATED
 
 var myApp = new SNS({
   platform: SNS.SUPPORTED_PLATFORMS.ANDROID,
@@ -141,6 +143,18 @@ function (endpointArn, deviceId) {}
 ```
 When a user is added this is emitted.
 
+#### attributesUpdateFailed
+```
+function (endpointArn, err) {}
+```
+If updating the attributes for an endpoint fails this is emitted.
+
+#### attributesUpdated
+```
+function (endpointArn, attributes) {}
+```
+When an endpoint's attributes are updated this is emitted.
+
 
 ## API
 
@@ -181,6 +195,15 @@ Get all users, this could take a while due to a potentially high number of reque
 
 #### addUser(deviceToken, [data], callback)
 Add a device/user to SNS with optional extra data. Callback has format fn(err, endpointArn).
+
+#### setAttributes(endpointArn, attributes, callback)
+Update an existing endpoint's attributes. Attributes is an object with the following optional properties:
+
+* CustomUserData: <object|string>
+* Enabled: <string>
+* Token: <string>
+
+Callback has format fn(err, endpointArn).
 
 #### deleteUser(endpointArn, callback)
 Delete a user from SNS. Callback has format callback(err)

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -18,7 +18,9 @@ var EMITTED_EVENTS = {
   DELETED_USER: 'userDeleted',
   FAILED_SEND: 'sendFailed',
   ADDED_USER: 'userAdded',
-  ADD_USER_FAILED: 'addUserFailed'
+  ADD_USER_FAILED: 'addUserFailed',
+  ATTRIBUTES_UPDATED: 'attributesUpdated',
+  ATTRIBUTES_UPDATE_FAILED: 'attributesUpdateFailed'
 };
 
 var async = require('async')
@@ -118,7 +120,7 @@ Interface.prototype.addUser = function(deviceId, customUserData, callback) {
     if (!err) {
       self.emit(EMITTED_EVENTS.ADDED_USER, res.EndpointArn, deviceId);
     } else {
-        self.emit(EMITTED_EVENTS.ADD_USER_FAILED, deviceId, err);
+      self.emit(EMITTED_EVENTS.ADD_USER_FAILED, deviceId, err);
     }
     return callback(err, ((res && res.EndpointArn) ? res.EndpointArn : null));
   });
@@ -141,6 +143,35 @@ Interface.prototype.getUser = function(endpointArn, callback) {
 
     res.EndpointArn = endpointArn;
     return callback(null, res);
+  });
+};
+
+
+/**
+ * Set a user's attributes by their EndpointArn
+ * @param {String}    endpointArn
+ * @param {Object}    attributes  An object that can contain string properties for CustomUserData, Enabled and Token
+ * @param {Function}  callback
+ */
+
+Interface.prototype.setAttributes = function(endpointArn, attributes, callback) {
+  var self = this;
+  if (typeof attributes == 'object') {
+    if (typeof attributes.CustomUserData == 'object') {
+      attributes.CustomUserData = JSON.stringify(attributes.CustomUserData);
+    }
+  }
+  var params = {
+    EndpointArn: endpointArn,
+    Attributes: attributes
+  };
+  this.sns.setEndpointAttributes(params, function(err, res) {
+    if (!err) {
+      self.emit(EMITTED_EVENTS.ATTRIBUTES_UPDATED, endpointArn, attributes);
+    } else {
+      self.emit(EMITTED_EVENTS.ATTRIBUTES_UPDATE_FAILED, endpointArn, err);
+    }
+    return callback(err, attributes);
   });
 };
 

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -156,10 +156,17 @@ Interface.prototype.getUser = function(endpointArn, callback) {
 
 Interface.prototype.setAttributes = function(endpointArn, attributes, callback) {
   var self = this;
-  if (typeof attributes == 'object') {
-    if (typeof attributes.CustomUserData == 'object') {
-      attributes.CustomUserData = JSON.stringify(attributes.CustomUserData);
+  var attributesType = typeof(attributes);
+  if (attributesType == 'object') {
+    try {
+      if (typeof attributes.CustomUserData == 'object') {
+        attributes.CustomUserData = JSON.stringify(attributes.CustomUserData);
+      }
+    } catch (e) {
+      return callback(e, null);
     }
+  } else {
+    return callback(new Error('Expected second parameter to be of type object (' + attributesType + ' supplied).'), null);
   }
   var params = {
     EndpointArn: endpointArn,

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,43 @@ describe('SNS Module.', function() {
     });
   });
 
+  it('Should retrieve a user by their EndpointArn and update their properties.', function(done) {
+    sns.addUser('anotherfakedeviceidthatimadeup', JSON.stringify({
+      username: 'fakeuserforattributetest'
+    }), function(err, endpointArn) {
+      sns.getUser(endpointArn, function(err, res) {
+
+        var attributes = {
+          CustomUserData: {
+            user_id: 'updated-attribute-user-id'
+          },
+          Enabled: 'true'
+        };
+        sns.setAttributes(res.EndpointArn, attributes, function(err, res) {
+          assert(!err);
+          assert(res === attributes);
+
+          sns.getUser(endpointArn, function(err, res) {
+            assert(!err);
+            assert(res.EndpointArn === endpointArn);
+            assert(res.Attributes);
+            assert(res.Attributes.Enabled === attributes.Enabled);
+            assert(res.Attributes.CustomUserData);
+            var responseUserData = JSON.parse(res.Attributes.CustomUserData);
+            var userData = JSON.parse(attributes.CustomUserData);
+            assert(responseUserData.user_id === userData.user_id);
+
+            sns.deleteUser(endpointArn, function(err) {
+              // delete test user we created so that we can re-run the test
+              done();
+            });
+          });
+
+        });
+      });
+    });
+  });
+
   it('Should retrieve a user by their EndpointArn and delete them', function(done) {
     sns.addUser('somefakedeviceidthatimadeup', JSON.stringify({
       username: 'fakeuser'

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,8 @@ var assert = require('assert'),
 var SNS_KEY_ID = process.env['SNS_KEY_ID'],
   SNS_ACCESS_KEY = process.env['SNS_ACCESS_KEY'],
   ANDROID_ARN = process.env['SNS_ANDROID_ARN'],
-  iOS_ARN = process.env['SNS_iOS_ARN'];
+  iOS_ARN = process.env['SNS_iOS_ARN'],
+  SNS_REGION = 'eu-west-1';
 
 console.log('Running tests with settings...\n');
 console.log('SNS_KEY_ID: %s\nSNS_ACCESS_KEY: %s\nSNS_ANDROID_ARN: %s\nSNS_iOS_ARN: %s\n', SNS_KEY_ID, SNS_ACCESS_KEY, ANDROID_ARN, iOS_ARN);
@@ -23,8 +24,8 @@ describe('SNS Module.', function() {
 
   it('Should create an instance of Interface', function() {
     sns = new SNS({
-      platform: 'android',
-      region: 'eu-west-1',
+      platform: SNS.SUPPORTED_PLATFORMS.ANDROID,
+      region: SNS_REGION,
       apiVersion: '2010-03-31',
       accessKeyId: SNS_ACCESS_KEY,
       secretAccessKey: SNS_KEY_ID,
@@ -36,8 +37,8 @@ describe('SNS Module.', function() {
 
   it('Should return correct apiVersion, region, PlatformApplicationArn', function() {
     sns = new SNS({
-      platform: 'android',
-      region: 'eu-west-1',
+      platform: SNS.SUPPORTED_PLATFORMS.ANDROID,
+      region: SNS_REGION,
       apiVersion: '2010-03-31',
       accessKeyId: SNS_ACCESS_KEY,
       secretAccessKey: SNS_KEY_ID,
@@ -46,15 +47,15 @@ describe('SNS Module.', function() {
 
     assert(sns);
     assert(sns.getApiVersion() === '2010-03-31');
-    assert(sns.getRegion() === 'eu-west-1');
+    assert(sns.getRegion() === SNS_REGION);
     assert(sns.getPlatformApplicationArn() === ANDROID_ARN);
   });
 
   // Replace SNS instance for each test
   beforeEach(function() {
     sns = new SNS({
-      platform: 'android',
-      region: 'eu-west-1',
+      platform: SNS.SUPPORTED_PLATFORMS.ANDROID,
+      region: SNS_REGION,
       apiVersion: '2010-03-31',
       accessKeyId: SNS_ACCESS_KEY,
       secretAccessKey: SNS_KEY_ID,

--- a/test/index.js
+++ b/test/index.js
@@ -117,12 +117,16 @@ describe('SNS Module.', function() {
             var userData = JSON.parse(attributes.CustomUserData);
             assert(responseUserData.user_id === userData.user_id);
 
-            sns.deleteUser(endpointArn, function(err) {
-              // delete test user we created so that we can re-run the test
-              done();
+            var emptyAttributes = {}; // empty attributes should generate an error
+            sns.setAttributes(endpointArn, emptyAttributes, function(err, res) {
+              assert(err);
+
+              sns.deleteUser(endpointArn, function(err) {
+                // Cleanup: delete test user we created so that we can re-run the test
+                done();
+              });
             });
           });
-
         });
       });
     });


### PR DESCRIPTION
Updates the unit tests to fix the invalid platform for the current version (1.x).

Moved the region to a new SNS_REGION variable for easier modification during local testing.

Added a new 'setAttributes' method to allow updating an existing user via their EndpointArn (useful for refreshing token or user information) with a new test case and two new events (attributesUpdated and AttributesUpdateFailed).