### PR TITLE
Allow custom AWS.SNS object in constructor

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -57,7 +57,7 @@ function Interface(opts) {
   this.platform = opts.platform;
   this.sandbox = opts.sandbox;
 
-  if (opts.sns){
+  if (opts.sns) {
     if (opts.sns instanceof AWS.SNS){
       this.sns = opts.sns;
     } else {

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -57,17 +57,25 @@ function Interface(opts) {
   this.platform = opts.platform;
   this.sandbox = opts.sandbox;
 
-  this.sns = new AWS.SNS({
-    region: opts.region,
-    apiVersion: opts.apiVersion,
-    accessKeyId: opts.accessKeyId,
-    secretAccessKey: opts.secretAccessKey
-  });
+  if (opts.sns){
+    if (opts.sns instanceof AWS.SNS){
+      this.sns = opts.sns;
+    } else {
+      this.sns = new AWS.SNS(opts.sns);
+    }
+  } else {
+    this.sns = new AWS.SNS({
+      region: opts.region,
+      apiVersion: opts.apiVersion,
+      accessKeyId: opts.accessKeyId,
+      secretAccessKey: opts.secretAccessKey
+    });
+  }
 
   events.EventEmitter.call(this);
 }
-util.inherits(Interface, events.EventEmitter);
 
+util.inherits(Interface, events.EventEmitter);
 
 Interface.EVENTS = EMITTED_EVENTS;
 Interface.SUPPORTED_PLATFORMS = SUPPORTED_PLATFORMS;

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,6 @@ describe('SNS Module.', function() {
     assert(sns.getPlatformApplicationArn() === ANDROID_ARN);
   });
 
-
   // Replace SNS instance for each test
   beforeEach(function() {
     sns = new SNS({

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 console.warn('Ensure that SNS_ACCESS_KEY, SNS_KEY_ID and SNS_ANDROID_ARN env vars are set for these tests!\n');
 
 var assert = require('assert'),
+  AWS = require('aws-sdk'),
   SNS = require('../lib/interface');
 
 var SNS_KEY_ID = process.env['SNS_KEY_ID'],
@@ -53,6 +54,33 @@ describe('SNS Module.', function() {
     assert(sns.getRegion() === SNS_REGION);
     assert(sns.getPlatformApplicationArn() === ANDROID_ARN);
   });
+
+  it('Should return correct apiVersion, region, PlatformApplicationArn when a custom SNS object is supplied', function() {
+    sns = new SNS({
+      platform: SNS.SUPPORTED_PLATFORMS.ANDROID,
+      platformApplicationArn: ANDROID_ARN,
+      sns: new AWS.SNS({region: SNS_REGION, apiVersion: '2010-03-31'})
+    });
+
+    assert(sns);
+    assert(sns.getApiVersion() === '2010-03-31');
+    assert(sns.getRegion() === SNS_REGION);
+    assert(sns.getPlatformApplicationArn() === ANDROID_ARN);
+  });
+
+  it('Should return correct apiVersion, region, PlatformApplicationArn when custom aws params are supplied', function() {
+    sns = new SNS({
+      platform: SNS.SUPPORTED_PLATFORMS.ANDROID,
+      platformApplicationArn: ANDROID_ARN,
+      sns: {region: SNS_REGION, apiVersion: '2014-02-01'}
+    });
+
+    assert(sns);
+    assert(sns.getApiVersion() === '2014-02-01');
+    assert(sns.getRegion() === SNS_REGION);
+    assert(sns.getPlatformApplicationArn() === ANDROID_ARN);
+  });
+
 
   // Replace SNS instance for each test
   beforeEach(function() {


### PR DESCRIPTION
Should resolve #9, let me know if there's anything I'm missing.

