### PR TITLE
Fix typo in README code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ androidApp.addUser('some_fake_deviceid_that_i_made_up', JSON.stringify({
   }
 
   // Send a simple String or data to the client
-  androidApp.sendMessage(enpointArn, 'Hi There!', function(err, messageId) {
+  androidApp.sendMessage(endpointArn, 'Hi There!', function(err, messageId) {
     if(err) {
       throw err;
     }


### PR DESCRIPTION
Fix `endpointArn` typo in the README example. 

Otherwise, you would get a `ReferenceError: enpointArn is not defined` from running it.