### PR TITLE
Added support to others protocols than `application` for subscriptions (eg `email` or `sms`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,10 +305,13 @@ Delete the topic with the given topicArn. The callback has the format fn(err).
 Send a message to a user. The _message_ parameter can be a String, or an Object with the formats below. The callback format is callback(err, messageId).
 
 #### subscribe(endpointArn, topicArn, callback)
-Subscribe an endpoint to a topic. The callback has the format fn(err, subscriptionArn).
+Subscribe an endpoint to a topic with the implicit `application` protocol. The callback has the format fn(err, subscriptionArn).
 
 #### unsubscribe(subscriptionArn, callback)
 Unsubscribe an endpoint from a topic via the given subscriptionArn. The callback has the format fn(err).
+
+#### subscribeWithProtocol(endpointArn, topicArn, protocol, callback)
+Subscribe an endpoint to a topic using a specific protocol such as `email` or `sms`. The callback has the format fn(err, subscriptionArn).
 
 #### publishToTopic(topicArn, message, callback)
 Publish a message a topic. The callback has the format fn(err, messageId).

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -508,17 +508,18 @@ Interface.prototype._getSubscriptions =
 
 
 /**
- * Subscribe an endpoint to a topic.
+ * Subscribe an endpoint to a topic with a given protocol.
  * @param {String}    endpointArn
  * @param {String}    topicArn
+ * @param {String}    protocol
  * @param {Function}  callback
  */
 
-Interface.prototype.subscribe = function(endpointArn, topicArn, callback) {
+Interface.prototype.subscribeWithProtocol = function(endpointArn, topicArn, protocol, callback) {
   var params = {
     Endpoint: endpointArn,
     TopicArn: topicArn,
-    Protocol: 'application'
+    Protocol: protocol
   };
   var self = this;
   self.sns.subscribe(params, function(err, res) {
@@ -537,6 +538,17 @@ Interface.prototype.subscribe = function(endpointArn, topicArn, callback) {
     );
     callback(null, res.SubscriptionArn);
   });
+};
+
+/**
+ * Subscribe an endpoint to a topic.
+ * @param {String}    endpointArn
+ * @param {String}    topicArn
+ * @param {Function}  callback
+ */
+
+Interface.prototype.subscribe = function(endpointArn, topicArn, callback) {
+  subscribeWithProtocol(endpointArn, topicArn, 'application', callback);
 };
 
 


### PR DESCRIPTION
Does not break API because a new `subscribeWithProtocol` method has been added but is called internally by `subscribe` with the default `application` protocol.