### PR TITLE
Push forward aws-sdk by nine hundred and forty-one minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sns-mobile",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Send push notifications to Android, Kindle Fire, and iOS devices easily.",
   "main": "index.js",
   "scripts": {
@@ -28,8 +28,8 @@
     "simple notification service"
   ],
   "dependencies": {
-    "async": "0.2.10",
-    "aws-sdk": "2.1.5"
+    "async": "^0.2.10",
+    "aws-sdk": "^2.1.5"
   },
   "devDependencies": {
     "linelint": "0.0.3",


### PR DESCRIPTION
The aws-sdk dependency being used here is hardcoded to a version six years out of date and lacks several features that lead to intermittent errors when it's used on cloud servers (e.g. it doesn't retry through transient network errors when fetching credentials on EC2/ECS instances).

This upgrade brings it up to date and changes the version constraint to let it continue updating in the future.